### PR TITLE
Update update() parsing to support newline update expressions

### DIFF
--- a/lib/method_logic/update.js
+++ b/lib/method_logic/update.js
@@ -8,15 +8,45 @@ module.exports = ((dynamoInstance, params, table) => {
     /* Next order of business... What values are you trying to update? */
     /* Well you want to take the values declared within `UpdateExpression` (split , -> split =) */
     const updates = params.UpdateExpression.split(' ');
+
     // unused for now ---> const updateOperation = updates.slice(0, 1);
 
-    /* man this makes me miss Python string manipulation... */
-    const updateValues = updates.slice(1, updates.length).join(' ').split(',');
+    // Build a list of update expression strings
+    const { updates: updatesFiltered } = _(updates)
+        .map((update) => update.replace(/(set|\n)/gi, ''))
+        .compact()
+        .reduce((memo, piece) => {
+            /**
+             * Handle the fact that some update expressions might use commas to delimit
+             *
+             * @type {String}
+             */
+            const cleanPiece = piece.replace(/,$/, '');
+
+            if (RegExp(/^#/).test(cleanPiece) && _.isNull(memo.workingUpdate)) { // Test for assignment variable
+                memo.workingUpdate = cleanPiece;
+            } else if (!_.isNull(memo.workingUpdate) && (
+                RegExp(/={1}/).test(cleanPiece) || // Test for valid operator
+                RegExp(/^:/).test(cleanPiece) // Test for assignment value
+            )) {
+                memo.workingUpdate += ` ${cleanPiece}`;
+            }
+
+            if (RegExp(/^:/).test(cleanPiece)) { // Complete expression update if have last piece in hand
+                memo.updates.push(memo.workingUpdate);
+                memo.workingUpdate = null; // reset working so we can move onto next
+            }
+
+            return memo;
+        }, {
+            workingUpdate: null,
+            updates: []
+        });
 
     /* Now you're dealing with a list of key value pairs seperated by a `=` */
     let updateObj = {};
 
-    _.forEach(updateValues, (obj) => {
+    _.forEach(updatesFiltered, (obj) => {
         /* `obj` represents the full equality such as #key = :value, split on = and grab the left side */
         let updateKey = obj.split('=')[0].replace(/\s/g, '');
 


### PR DESCRIPTION
Ran into issues where UpdateExpression values with newlines (string literals/templates) were causing issues.  Reworked the update parsing to handle these cases and move to more explicit cleaning rules.