### PR TITLE
Support key conditions with multiple operators

### DIFF
--- a/lib/method_logic/query.js
+++ b/lib/method_logic/query.js
@@ -5,8 +5,10 @@ const _ = require('lodash');
 /* So basically we need to apply all of the `conditions` to item, if it pass return it. */
 const applyConditionalOperators = (params, item, conditions) => {
     /* How about first you take care of = and make sure your test still passes? */
-    const names = params.ExpressionAttributeNames;
-    const values = params.ExpressionAttributeValues;
+    const {
+        ExpressionAttributeNames: attributeNames,
+        ExpressionAttributeValues: attributeValues
+    } = params;
 
     const checkCondition = {
         /* Behavior for Conditional Operator begins_with */
@@ -134,28 +136,17 @@ const applyConditionalOperators = (params, item, conditions) => {
         }
     };
 
-    let validDocument = true;
-
-    _.forOwn(conditions, (value, key) => {
-        if (_.isEmpty(value.matches)) {
-            return;
-        }
-
-        _.forEach(value.matches, (condition) => {
-            /* RegExp match is an Array of 3 values - the first is the matched string. */
-            const match = _.head(condition);
-            validDocument = checkCondition[key].check(item, match, names, values);
-        });
-    });
-    return validDocument;
+    // Assume ANDs for implementation
+    return _.every(conditions, ({ matches, key }) => _.every(matches, (requiredConditionMatch) =>
+        checkCondition[key].check(item, requiredConditionMatch, attributeNames, attributeValues)
+    ));
 };
 
 module.exports = ((dynamoInstance, params, table) => {
     /* Sadly we don't even support less than equals to and what not yet - but using regex we can easily XD. */
-    //const supportedConditions = ['=', 'between', 'begins_with'];
     const regexConditions = {
         '=': {
-            expression: /#?[a-zA-Z\_]+ = :?[0-9a-zA-Z\_\-]+/,
+            expression: /#?[a-zA-Z\_]+ = :?[0-9a-zA-Z\_\-]+/g,
             matches: []
         },
         '<': {
@@ -186,20 +177,14 @@ module.exports = ((dynamoInstance, params, table) => {
         AttributesToGet: attributesToGet
     } = params;
 
-    _.forOwn(regexConditions, (value, key) => {
-        /* Execute each of our supported Conditional Expressions to look for matches. */
-        const match = value.expression.exec(conditions);
-        if (!_.isNil(match)) {
-            value.matches.push(match);
-        }
-    });
+    const conditionsToUse = _(regexConditions)
+        .map(({ expression }, key) => _.merge({ key }, { matches: conditions.match(expression) }))
+        .filter(({ matches }) => !_.isNull(matches))
+        .value();
 
     const queryResults = _(dynamoInstance.context[table])
         /* Looping through each entry in the table... lets go ahead and check if it matches our conditions? */
-        .map((item) => {
-            return applyConditionalOperators(params, item, regexConditions) ? item : null;
-        })
-        .compact()
+        .filter((item) => applyConditionalOperators(params, item, conditionsToUse))
         .value();
 
     const querySelect = _.isUndefined(selectValue) ? 'ALL_ATTRIBUTES' : selectValue;


### PR DESCRIPTION
Ran into an issue where expressions such as `#user_id = :user_id and #resource_id = :resource_id` were returning entries they shouldn't.  Re-worked query logic to appropriately consider multiple conditions within a KeyCondition expression.