### PR TITLE
Updating how core mocking works with callback

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -52,14 +52,10 @@ class Dynamock {
                     console.log(params, 'params');
                     console.log(cb, 'cb');
 
-                    return this.dynamockInstance.validateMethod(method, params)
-                        .then(() => {
-                            if (cb) {
-                                return cb(null, this.dynamockInstance.invoke(method, params, params.TableName));
-                            }
-                            return Promise.resolve(this.dynamockInstance.invoke(method, params, params.TableName));
-                        })
-                        .catch((err) => cb(err, null));
+                    const invokePromise = this.dynamockInstance.validateMethod(method, params)
+                        .then(() => this.dynamockInstance.invoke(method, params, params.TableName));
+
+                    return cb(null, invokePromise);
                 });
             } else {
                 this.AWS.mock('DynamoDB.DocumentClient', method, (params, cb) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cbtnuggets/lib-dynamock-nodejs",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Mocked Dynamo implementation that allows Dynamo API calls to interact with a local in-memory storage system.",
   "main": "lib/core.js",
   "keywords": [


### PR DESCRIPTION
- Previous implementation of mocked functionality wasn't working as `service-exam-provider` uses the `.promise()` functionality when making calls, and to make sure this mocked function worked for `.promise()` or with a callback, we needed to use the callback at the top-level, not return a promise.